### PR TITLE
Allow gitlab pages to be slow

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -16,6 +16,7 @@ sites:
     url: https://poorna.smc.org.in
     __dangerous__disable_verify_peer: true
     expectedStatusCodes: [200]
+    maxResponseTime: 120000
     assignees: 
     - mujeebcpy
   - name: Community


### PR DESCRIPTION
Poorna keeps sending grey positives when gitlab pages is having operational issues. There's nothing we need to do about it and therefore, we're better off not triggering the warning. Ideally we need a way to ignore one failure and recheck in next cycle. But extending maxResponseTime to 120 seconds (from default of 30) will help in cases where the gitlab database is slow